### PR TITLE
Add support for text gdiplus v2

### DIFF
--- a/Python/Stagedisplay viewer V0_23.py
+++ b/Python/Stagedisplay viewer V0_23.py
@@ -282,7 +282,7 @@ def script_properties():
     if sources is not None:
         for source in sources:
             source_id = obs.obs_source_get_id(source)
-            if source_id == "text_gdiplus" or source_id == "text_ft2_source":
+            if source_id == "text_gdiplus" or source_id == "text_ft2_source" or source_id == "text_gdiplus_v2":
                 name = obs.obs_source_get_name(source)
                 obs.obs_property_list_add_string(p1, name, name)
                 obs.obs_property_list_add_string(p2, name, name)


### PR DESCRIPTION
New version of OBS uses text_gdiplus_v2 for text sources... old script won't work without adding support for v2